### PR TITLE
Free allocated objects

### DIFF
--- a/ext/majo/allocation_info.c
+++ b/ext/majo/allocation_info.c
@@ -2,13 +2,12 @@
 
 static void majo_allocation_info_mark(void *ptr)
 {
-  // TODO
   majo_allocation_info *info = (majo_allocation_info*)ptr;
+  rb_gc_mark(info->result);
 }
 
 static void majo_allocation_info_free(majo_allocation_info *info) {
-  // TODO
-  ruby_xfree(info);
+  free(info);
 }
 
 static size_t majo_allocation_info_memsize(const void *ptr) {

--- a/ext/majo/allocation_info.h
+++ b/ext/majo/allocation_info.h
@@ -11,6 +11,8 @@ typedef struct {
   size_t alloc_generation;
   size_t free_generation;
   size_t memsize;
+
+  VALUE result;
 } majo_allocation_info;
 
 VALUE


### PR DESCRIPTION
Close #3 


## Strategy of memory management


* Premise
  * All `allocation_info` have shared char pointers
  * The shared char pointers are managed by the `result` object
* The `allocation_info` does not manage the char pointers
* Instead, it has a reference to the `result` marked by `rb_gc_mark()`.
  * With this reference, `result` object is not free while `allocation_info` exist
* `result` object manages the shared strings


The shared strings are lazily free at the same time as `result` is free. I think it is acceptable.