### PR TITLE
Add options for upper and lower threshold of lifetime

### DIFF
--- a/ext/majo/result.c
+++ b/ext/majo/result.c
@@ -6,6 +6,8 @@ static void majo_result_mark(void *ptr)
   rb_gc_mark(arg->newobj_trace);
   rb_gc_mark(arg->freeobj_trace);
   rb_gc_mark(arg->retained);
+  rb_gc_mark(arg->upper_lifetime);
+  rb_gc_mark(arg->lower_lifetime);
 }
 
 static int

--- a/ext/majo/result.h
+++ b/ext/majo/result.h
@@ -8,6 +8,9 @@ typedef struct {
   VALUE newobj_trace;
   VALUE freeobj_trace;
   VALUE retained;
+
+  VALUE upper_lifetime;
+  VALUE lower_lifetime;
 } majo_result;
 
 VALUE

--- a/lib/majo.rb
+++ b/lib/majo.rb
@@ -10,11 +10,11 @@ require_relative 'majo/formatter'
 module Majo
   class Error < StandardError; end
 
-  def self.start
+  def self.start(upper_lifetime: nil, lower_lifetime: 1)
     GC.start
     GC.start
     GC.start
-    __start
+    __start(upper_lifetime, lower_lifetime)
   end
 
   def self.stop
@@ -29,8 +29,8 @@ module Majo
     end
   end
 
-  def self.run
-    r = start
+  def self.run(upper_lifetime: nil, lower_lifetime: 1)
+    r = start(upper_lifetime:, lower_lifetime:)
     yield
     r
   ensure


### PR DESCRIPTION
Close #27



The `lifetime` is defined as the number of GC that the object survives.
For example, `run(lower_lifetime: 1)` means the result includes objects surviving at least 1 GC.

Note that the `lower_lifetime` does not work for retained objects because Majo cannot estimate the lifetime of retained objects. All retained objects are included in the result even if `lower_lifetime` is used.
BTW, `upper_lifetime` works for the retained objects. 